### PR TITLE
Fix HTML double unescaping

### DIFF
--- a/src/_includes/layouts/robots.njk
+++ b/src/_includes/layouts/robots.njk
@@ -128,10 +128,10 @@ layout: base.njk
 <script>
   function htmlUnescape(str) {
     return str
-      .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
       .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'");
+      .replace(/&#39;/g, "'")
+      .replace(/&amp;/g, '&');
   }
 </script>


### PR DESCRIPTION
Potential fix for [https://github.com/thedropbears/website/security/code-scanning/2](https://github.com/thedropbears/website/security/code-scanning/2)

To fix this without changing intended functionality, keep the same replacements but reorder them so `&amp;` is unescaped **after** all other entities. This prevents newly created `&...;` sequences from being decoded again in the same pass.

In `src/_includes/layouts/robots.njk`, update the `htmlUnescape` function (lines 129–136 region) so `.replace(/&amp;/g, '&')` is the last replacement in the chain. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
