### PR TITLE
image performance stuff

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,32 +2,68 @@ const yaml = require("js-yaml");
 const htmlmin = require("html-minifier");
 const Image = require("@11ty/eleventy-img");
 
-// Image shortcode for responsive images
-async function imageShortcode(src, alt, sizes = "100vw") {
-  if (!src) {
-    throw new Error(`Missing image path: ${src}`);
-  }
+// Normalize a web path (/static/img/foo.jpg) to a filesystem source path.
+function imageInputPath(src) {
+  return src.startsWith("/static/") ? "./src" + src : src;
+}
 
-  let metadata = await Image(src, {
+// Generate (or reuse cached) responsive image variants for a source image.
+async function generateImageMetadata(src) {
+  return await Image(imageInputPath(src), {
     widths: [300, 600, 900, 1200],
     formats: ["webp", "jpeg"],
     urlPath: "/static/img/",
     outputDir: "./_site/static/img/",
     filenameFormat: function (id, src, width, format) {
-      const extension = format;
       const name = src.split("/").pop().split(".")[0];
-      return `${name}-${width}w.${extension}`;
+      return `${name}-${width}w.${format}`;
     }
   });
+}
+
+// Responsive <picture> shortcode. Pass eager=true for above-the-fold images
+// (the LCP element) so they load with high priority instead of lazily.
+async function imageShortcode(src, alt, sizes = "100vw", className = "", eager = false) {
+  if (!src) {
+    throw new Error(`Missing image path: ${src}`);
+  }
+
+  let metadata = await generateImageMetadata(src);
 
   let imageAttributes = {
     alt,
     sizes,
-    loading: "lazy",
+    loading: eager ? "eager" : "lazy",
     decoding: "async",
   };
+  if (className) {
+    imageAttributes.class = className;
+  }
+  if (eager) {
+    imageAttributes.fetchpriority = "high";
+  }
 
   return Image.generateHTML(metadata, imageAttributes);
+}
+
+// Return the URL of the largest optimized WebP variant for a source image.
+// Used where a single src is needed at runtime (e.g. Alpine bindings).
+async function imageUrlShortcode(src) {
+  if (!src) {
+    return "";
+  }
+  let metadata = await generateImageMetadata(src);
+  let webp = metadata.webp;
+  return webp[webp.length - 1].url;
+}
+
+// Return a srcset string for a source image, for use in <link rel="preload">.
+async function imageSrcsetShortcode(src, format = "webp") {
+  if (!src) {
+    return "";
+  }
+  let metadata = await generateImageMetadata(src);
+  return (metadata[format] || []).map((entry) => entry.srcset).join(", ");
 }
 
 module.exports = function (eleventyConfig) {
@@ -37,9 +73,10 @@ module.exports = function (eleventyConfig) {
   // Merge data instead of overriding
   eleventyConfig.setDataDeepMerge(true);
 
-  // Add image shortcode
-  eleventyConfig.addNunjucksAsyncShortcode("image", imageShortcode);
-  eleventyConfig.addJavaScriptFunction("image", imageShortcode);
+  // Add image shortcodes (universal: available in njk, liquid and markdown)
+  eleventyConfig.addAsyncShortcode("image", imageShortcode);
+  eleventyConfig.addAsyncShortcode("imageUrl", imageUrlShortcode);
+  eleventyConfig.addAsyncShortcode("imageSrcset", imageSrcsetShortcode);
 
   // Array slice filter for collections
   eleventyConfig.addFilter("slice", (array, start, end) => {

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -39,7 +39,7 @@ layout: base.njk
           </div>
         </div>
         <div>
-          <img src="/static/img/hero-robot.jpg" alt="The Drop Bears Robot" class="rounded-lg shadow-lg">
+          {% image "/static/img/hero-robot.jpg", "The Drop Bears Robot", "(min-width: 768px) 50vw, 100vw", "rounded-lg shadow-lg", true %}
         </div>
       </div>
     </div>

--- a/src/_includes/layouts/page.njk
+++ b/src/_includes/layouts/page.njk
@@ -5,7 +5,7 @@ layout: base.njk
 <div class="container mx-auto px-6 py-8 md:py-12">
   {% if featuredImage %}
     <div class="mb-8">
-      <img src="{{ featuredImage }}" alt="{{ title }}" class="w-full h-64 md:h-96 object-cover rounded-lg shadow-md">
+      {% image featuredImage, title, "100vw", "w-full h-64 md:h-96 object-cover rounded-lg shadow-md" %}
     </div>
   {% endif %}
   

--- a/src/_includes/layouts/robots.njk
+++ b/src/_includes/layouts/robots.njk
@@ -8,7 +8,7 @@ layout: base.njk
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
     {% for robot in collections.robots %}
       <div class="bg-white border border-gray-200 rounded-lg shadow-md overflow-hidden">
-        <img src="{{ robot.data.image }}" alt="{{ robot.data.robotName }}" class="w-full h-48 object-cover">
+        {% image robot.data.image, robot.data.robotName, "(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw", "w-full h-48 object-cover" %}
         <div class="p-5">
           <h2 class="text-2xl font-bold text-primary">{{ robot.data.robotName }}</h2>
           <p class="text-gray-600">{{ robot.data.year }} - {{ robot.data.gameName }}</p>
@@ -40,7 +40,7 @@ layout: base.njk
             data-robot-name="{{ robot.data.robotName }}"
             data-robot-year="{{ robot.data.year }}"
             data-robot-game="{{ robot.data.gameName }}"
-            data-robot-image="{{ robot.data.image }}"
+            data-robot-image="{% imageUrl robot.data.image %}"
             data-robot-description="{{ robot.content | safe | htmlescape }}"
             data-robot-awards='[{% for award in robot.data.awards %}{"award": "{{ award.award }}"}{% if not loop.last %},{% endif %}{% endfor %}]'
             class="inline-block mt-4 px-4 py-2 bg-primary text-white rounded hover:bg-blue-800 transition">
@@ -95,7 +95,7 @@ layout: base.njk
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
           <!-- image -->
             <div>
-              <img :src="selectedRobot?.image" :alt="selectedRobot?.name" class="w-full h-auto rounded-lg shadow-md">
+              <img :src="selectedRobot?.image" :alt="selectedRobot?.name" loading="lazy" decoding="async" class="w-full h-auto rounded-lg shadow-md">
             </div>
             
             <!-- awards -->

--- a/src/_includes/partials/head.njk
+++ b/src/_includes/partials/head.njk
@@ -43,6 +43,11 @@
   <meta name="twitter:image" content="{{ ogImageUrl }}">
 {% endif %}
 
+<!-- Preload the homepage hero (LCP image) -->
+{% if page.url == "/" %}
+  <link rel="preload" as="image" type="image/webp" imagesrcset="{% imageSrcset '/static/img/hero-robot.jpg' %}" imagesizes="(min-width: 768px) 50vw, 100vw">
+{% endif %}
+
 <!-- Favicon -->
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 

--- a/src/_pages/info.md
+++ b/src/_pages/info.md
@@ -28,7 +28,7 @@ During Term time: Saturday, Sunday 11am – 5pm and Thursday, Friday, Monday 4pm
 ### Mechanical
 
 <div class="md:flex md:items-center md:gap-6">
-  <img src="/static/img/mechanical.png" alt="Mechanical assembly work" class="w-full md:w-1/3 mb-4 rounded-lg shadow-md">
+  {% image "/static/img/mechanical.png", "Mechanical assembly work", "(min-width: 768px) 33vw, 100vw", "w-full md:w-1/3 mb-4 rounded-lg shadow-md" %}
   <div class="md:w-2/3">
   
   The Mechanical Team is charged with the nuts and bolts of engineering the robot.


### PR DESCRIPTION
TLDR: 5.8 MB → 67 KB  hero image loading, and simliar reductions fro all other images (excl. svg), and loading the hero image not lazily so it doesnt appear seconds after opening the site.

i have some more stuff i wanna add before its ready to merge

claude summary:
> **Item 1 — routed images through the shortcode:**
> - `home.njk` hero, `page.njk` featured image, `info.md` mechanical photo, and the `robots.njk` card grid now emit responsive `<picture>` (WebP + JPEG, 300/600/900/1200w) with the original Tailwind classes preserved and explicit `width`/`height` (free CLS protection).
> 
> **Item 2 — hero is no longer lazy:**
> - Hero renders with `loading="eager" fetchpriority="high"`.
> - `head.njk` preloads the hero's WebP srcset, but only on `page.url == "/"`.
> 
> **Item 3 — dynamic robots page:**
> - Card images use the build-time shortcode.
> - The modal's `data-robot-image` now points at the optimized 1200w WebP via `{% imageUrl %}` (so the Alpine modal loads ~67 KB instead of the multi-MB original), and the modal `<img>` got `loading="lazy" decoding="async"`.